### PR TITLE
kobo frontlight codebase overhaul

### DIFF
--- a/doc/Hacking.md
+++ b/doc/Hacking.md
@@ -4,10 +4,11 @@ Hacking
 Developing UI Widgets
 ---------------------
 
-If you need to create new UI widgets, `utils/wbuilder.lua` is your friend. It
+`utils/wbuilder.lua` is your friend, if you need to create new UI widgets. It
 sets up a minimal environment to bootstrap KOReader's UI framework to avoid
 starting the whole reader. This gives you quick feedback loop while iterating
-through your widget changes.
+through your widget changes. It's also a handy tool for debugging widget
+issues.
 
 To get a taste of how it works, try running this command at the root of
 KOReader's source tree:
@@ -19,5 +20,5 @@ KOReader's source tree:
 It will spawn up an emulator window with a grid and simple timer widget for
 demonstration.
 
-You can add your own `UIManager:show` show call at the end of
-`utils/wbuilder.lua` to test your new widget.
+You can add more `UIManager:show` call at the end of `utils/wbuilder.lua` to
+test your new widgets.

--- a/frontend/apps/reader/modules/readerfrontlight.lua
+++ b/frontend/apps/reader/modules/readerfrontlight.lua
@@ -63,7 +63,7 @@ function ReaderFrontLight:onShowIntensity()
     local powerd = Device:getPowerDevice()
     if powerd.fl_intensity ~= nil then
         UIManager:show(Notification:new{
-            text = T( _("Frontlight intensity is set to %1."), powerd.fl_intensity),
+            text = T(_("Frontlight intensity is set to %1."), powerd.fl_intensity),
             timeout = 1.0,
         })
     end

--- a/frontend/apps/reader/modules/readerfrontlight.lua
+++ b/frontend/apps/reader/modules/readerfrontlight.lua
@@ -40,17 +40,17 @@ end
 
 function ReaderFrontLight:onAdjust(arg, ges)
     local powerd = Device:getPowerDevice()
-    if powerd.flIntensity ~= nil then
-        DEBUG("frontlight intensity", powerd.flIntensity)
+    if powerd.fl_intensity ~= nil then
+        DEBUG("frontlight intensity", powerd.fl_intensity)
         local step = math.ceil(#self.steps * ges.distance / self.gestureScale)
         DEBUG("step = ", step)
         local delta_int = self.steps[step] or self.steps[#self.steps]
         DEBUG("delta_int = ", delta_int)
         local new_intensity
         if ges.direction == "north" then
-            new_intensity = powerd.flIntensity + delta_int
+            new_intensity = powerd.fl_intensity + delta_int
         elseif ges.direction == "south" then
-            new_intensity = powerd.flIntensity - delta_int
+            new_intensity = powerd.fl_intensity - delta_int
         end
         if new_intensity ~= nil then
             powerd:setIntensity(new_intensity)
@@ -61,9 +61,9 @@ end
 
 function ReaderFrontLight:onShowIntensity()
     local powerd = Device:getPowerDevice()
-    if powerd.flIntensity ~= nil then
+    if powerd.fl_intensity ~= nil then
         UIManager:show(Notification:new{
-            text = T( _("Frontlight intensity is set to %1."), powerd.flIntensity),
+            text = T( _("Frontlight intensity is set to %1."), powerd.fl_intensity),
             timeout = 1.0,
         })
     end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,9 +1,9 @@
 local BasePowerD = {
-    fl_min = 0,      -- min frontlight intensity
-    fl_max = 10,     -- max frontlight intensity
-    fl_intensity = nil,   -- frontlight intensity
+    fl_min = 0,          -- min frontlight intensity
+    fl_max = 10,         -- max frontlight intensity
+    fl_intensity = nil,  -- frontlight intensity
     battCapacity = nil,  -- battery capacity
-    device = nil,    -- device object
+    device = nil,        -- device object
 
     capacity_pulled_count = 0,
     capacity_cached_count = 10,
@@ -57,6 +57,7 @@ function BasePowerD:normalizeIntensity(intensity)
 end
 
 function BasePowerD:setIntensity(intensity)
+    if intensity == self.fl_intensity then return end
     self.fl_intensity = self:normalizeIntensity(intensity)
     self:setIntensityHW()
 end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -1,7 +1,7 @@
 local BasePowerD = {
     fl_min = 0,      -- min frontlight intensity
     fl_max = 10,     -- max frontlight intensity
-    flIntensity = nil,   -- frontlight intensity
+    fl_intensity = nil,   -- frontlight intensity
     battCapacity = nil,  -- battery capacity
     device = nil,    -- device object
 
@@ -57,7 +57,7 @@ function BasePowerD:normalizeIntensity(intensity)
 end
 
 function BasePowerD:setIntensity(intensity)
-    self.flIntensity = self:normalizeIntensity(intensity)
+    self.fl_intensity = self:normalizeIntensity(intensity)
     self:setIntensityHW()
 end
 

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -4,7 +4,7 @@ local BasePowerD = require("device/generic/powerd")
 local KindlePowerD = BasePowerD:new{
     fl_min = 0, fl_max = 24,
 
-    flIntensity = nil,
+    fl_intensity = nil,
     battCapacity = nil,
     is_charging = nil,
     lipc_handle = nil,
@@ -17,9 +17,9 @@ function KindlePowerD:init()
     end
     if self.device.hasFrontlight() then
         if self.lipc_handle ~= nil then
-            self.flIntensity = self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
+            self.fl_intensity = self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
         else
-            self.flIntensity = self:read_int_file(self.fl_intensity_file)
+            self.fl_intensity = self:read_int_file(self.fl_intensity_file)
         end
     end
 end
@@ -27,7 +27,7 @@ end
 function KindlePowerD:toggleFrontlight()
     local sysint = self:read_int_file(self.fl_intensity_file)
     if sysint == 0 then
-        self:setIntensity(self.flIntensity)
+        self:setIntensity(self.fl_intensity)
     else
         os.execute("echo -n 0 > " .. self.fl_intensity_file)
     end
@@ -35,9 +35,9 @@ end
 
 function KindlePowerD:setIntensityHW()
     if self.lipc_handle ~= nil then
-        self.lipc_handle:set_int_property("com.lab126.powerd", "flIntensity", self.flIntensity)
+        self.lipc_handle:set_int_property("com.lab126.powerd", "flIntensity", self.fl_intensity)
     else
-        os.execute("echo -n ".. self.flIntensity .." > " .. self.fl_intensity_file)
+        os.execute("echo -n ".. self.fl_intensity .." > " .. self.fl_intensity_file)
     end
 end
 

--- a/frontend/device/kobo/nickel_conf.lua
+++ b/frontend/device/kobo/nickel_conf.lua
@@ -57,9 +57,9 @@ function NickelConf.frontLightLevel.get()
     if new_intensity then
         return powerd:normalizeIntensity(new_intensity)
     else
-        local fallback_FrontLightLevel = powerd.flIntensity or 1
-        assert(NickelConf.frontLightLevel.set(fallback_FrontLightLevel))
-        return fallback_FrontLightLevel
+        local fallback_fl_level = powerd.fl_intensity or 1
+        assert(NickelConf.frontLightLevel.set(fallback_fl_level))
+        return fallback_fl_level
     end
 end
 

--- a/frontend/device/kobo/nickel_conf.lua
+++ b/frontend/device/kobo/nickel_conf.lua
@@ -73,7 +73,7 @@ function NickelConf.frontLightState.get()
     return new_state
 end
 
-function NickelConf._write_kobo_conf(re_Match, key, value)
+function NickelConf._write_kobo_conf(re_Match, key, value, dont_create)
     local kobo_conf = io.open(kobo_conf_path, "r")
     local lines = {}
     local found = false
@@ -108,7 +108,7 @@ function NickelConf._write_kobo_conf(re_Match, key, value)
         kobo_conf:close()
     end
 
-    if not found then
+    if not found and dont_create ~= true then
         if not correct_section then
             lines[#lines + 1] = "[PowerOptions]"
         end
@@ -140,7 +140,9 @@ function NickelConf.frontLightState.set(new_state)
            "Wrong front light state value type (expect boolean)!")
     return NickelConf._write_kobo_conf(re_FrontLightState,
                                        front_light_state_str,
-                                       new_state)
+                                       new_state,
+                                       -- do not create this entry is missing
+                                       true)
 end
 
 return NickelConf

--- a/frontend/device/kobo/nickel_conf.lua
+++ b/frontend/device/kobo/nickel_conf.lua
@@ -68,12 +68,8 @@ function NickelConf.frontLightState.get()
     if new_state then
         new_state = (new_state == "true") or false
     end
-
-    if new_state == nil then
-        assert(NickelConf.frontLightState.set(false))
-        return false
-    end
-
+    -- for devices that do not have toggle button, the entry will be missing
+    -- and we return nil in this case.
     return new_state
 end
 

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -8,11 +8,11 @@ local KoboPowerD = BasePowerD:new{
     -- Do not actively set front light to 0, it may confuse users -- pressing
     -- hardware button won't take any effect.
     fl_min = 1, fl_max = 100,
-    flIntensity = 20,
+    fl_intensity = 20,
     restore_settings = true,
     fl = nil,
-
-    flState = false,
+    -- this attribute should be synced with nickel's FrontLightState config
+    is_fl_on = false,
     batt_capacity_file = batt_state_folder .. "capacity",
     is_charging_file = batt_state_folder .. "status",
     battCapacity = nil,
@@ -29,23 +29,23 @@ end
 
 function KoboPowerD:toggleFrontlight()
     if self.fl ~= nil then
-        if self.flState then
+        if self.is_fl_on then
             self.fl:setBrightness(0)
         else
-            self.fl:setBrightness(self.flIntensity)
+            self.fl:setBrightness(self.fl_intensity)
         end
-        self.flState = not self.flState
+        self.is_fl_on = not self.is_fl_on
         if KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
-            NickelConf.frontLightState.set(self.flState)
+            NickelConf.frontLightState.set(self.is_fl_on)
         end
     end
 end
 
 function KoboPowerD:setIntensityHW()
     if self.fl ~= nil then
-        self.fl:setBrightness(self.flIntensity)
+        self.fl:setBrightness(self.fl_intensity)
         if KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
-            NickelConf.frontLightLevel.set(self.flIntensity)
+            NickelConf.frontLightLevel.set(self.fl_intensity)
         end
     end
 end
@@ -72,8 +72,8 @@ function KoboPowerD:afterResume()
     if self.fl ~= nil then
         if KOBO_LIGHT_ON_START and tonumber(KOBO_LIGHT_ON_START) > -1 then
             self:setIntensity(math.min(KOBO_LIGHT_ON_START, 100))
-        else
-            self.fl:setBrightness(self.flIntensity)
+        elseif self.is_fl_on then
+            self.fl:setBrightness(self.fl_intensity)
         end
     end
 end

--- a/frontend/device/kobo/powerd.lua
+++ b/frontend/device/kobo/powerd.lua
@@ -13,8 +13,8 @@ local KoboPowerD = BasePowerD:new{
     fl = nil,
 
     -- We will set this value for all kobo models. but it will only be synced
-    -- with nickel's FrontLightState config if the current model has a
-    -- frontlight toggle button.
+    -- with nickel's FrontLightState config if the current nickel firmware
+    -- supports this config.
     is_fl_on = false,
 
     batt_capacity_file = batt_state_folder .. "capacity",
@@ -30,9 +30,9 @@ function KoboPowerD:init()
         if ok then
             self.fl = light
             if NickelConf.frontLightState.get() ~= nil then
-                self.has_fl_toggle_btn = true
+                self.has_fl_state_cfg = true
             else
-                self.has_fl_toggle_btn = false
+                self.has_fl_state_cfg = false
             end
         end
     end
@@ -46,7 +46,7 @@ function KoboPowerD:toggleFrontlight()
             self.fl:setBrightness(self.fl_intensity)
         end
         self.is_fl_on = not self.is_fl_on
-        if self.has_fl_toggle_btn and KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
+        if self.has_fl_state_cfg and KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
             NickelConf.frontLightState.set(self.is_fl_on)
         end
     end
@@ -67,7 +67,7 @@ function KoboPowerD:setIntensityHW()
         end
         if self.is_fl_on ~= is_fl_on then
             self.is_fl_on = is_fl_on
-            if self.has_fl_toggle_btn and KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
+            if self.has_fl_state_cfg and KOBO_SYNC_BRIGHTNESS_WITH_NICKEL then
                 NickelConf.frontLightState.set(self.is_fl_on)
             end
         end

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -64,23 +64,23 @@ function UIManager:init()
         local kobo_light_on_start = tonumber(KOBO_LIGHT_ON_START)
         if kobo_light_on_start then
             local new_intensity
-            local new_state
+            local is_fl_on
             if kobo_light_on_start > 0 then
                 new_intensity = math.min(kobo_light_on_start, 100)
-                new_state = true
+                is_fl_on = true
             elseif kobo_light_on_start == 0 then
-                new_state = false
+                is_fl_on = false
             elseif kobo_light_on_start == -2 then
                 local NickelConf = require("device/kobo/nickel_conf")
                 new_intensity = NickelConf.frontLightLevel.get()
-                new_state = NickelConf.frontLightState:get()
-                if new_state == nil then
+                is_fl_on = NickelConf.frontLightState:get()
+                if is_fl_on == nil then
                     -- this device does not support frontlight toggle,
-                    -- we set the state based on frontlight intensity.
+                    -- we set the value based on frontlight intensity.
                     if new_intensity > 0 then
-                        new_state = true
+                        is_fl_on = true
                     else
-                        new_state = false
+                        is_fl_on = false
                     end
                 end
             end
@@ -90,7 +90,7 @@ function UIManager:init()
                 G_reader_settings:saveSetting("frontlight_intensity",
                                               new_intensity)
             end
-            G_reader_settings:saveSetting("frontlight_state", new_state)
+            G_reader_settings:saveSetting("is_frontlight_on", is_fl_on)
         end
     elseif Device:isKindle() then
         self.event_handlers["IntoSS"] = function()

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -74,12 +74,21 @@ function UIManager:init()
                 local NickelConf = require("device/kobo/nickel_conf")
                 new_intensity = NickelConf.frontLightLevel.get()
                 new_state = NickelConf.frontLightState:get()
+                if new_state == nil then
+                    -- this device does not support frontlight toggle,
+                    -- we set the state based on frontlight intensity.
+                    if new_intensity > 0 then
+                        new_state = true
+                    else
+                        new_state = false
+                    end
+                end
             end
+            -- Since this kobo-specific, we save all values in settings here
+            -- and let the code (reader.lua) pick it up later during bootstrap.
             if new_intensity then
-                -- Since this kobo-specific, we save here and let the code pick
-                -- it up later from the reader settings.
-                G_reader_settings:saveSetting(
-                    "frontlight_intensity", new_intensity)
+                G_reader_settings:saveSetting("frontlight_intensity",
+                                              new_intensity)
             end
             G_reader_settings:saveSetting("frontlight_state", new_state)
         end

--- a/kodev
+++ b/kodev
@@ -130,7 +130,7 @@ ${SUPPORTED_TARGETS}"
             ;;
         android)
             make TARGET=android clean
-            rm *.apk
+            rm -f *.apk
             ;;
         pocketbook)
             make TARGET=pocketbook clean

--- a/reader.lua
+++ b/reader.lua
@@ -121,7 +121,7 @@ if Device:isKobo() then
     local powerd = Device:getPowerDevice()
     if powerd and powerd.restore_settings then
         local intensity = G_reader_settings:readSetting("frontlight_intensity")
-        powerd.flIntensity = intensity or powerd.flIntensity
+        powerd.fl_intensity = intensity or powerd.fl_intensity
         local state = G_reader_settings:readSetting("frontlight_state")
         if state then
             -- Default state is off

--- a/reader.lua
+++ b/reader.lua
@@ -122,14 +122,14 @@ if Device:isKobo() then
     if powerd and powerd.restore_settings then
         local intensity = G_reader_settings:readSetting("frontlight_intensity")
         powerd.fl_intensity = intensity or powerd.fl_intensity
-        local state = G_reader_settings:readSetting("frontlight_state")
-        if state then
-            -- default state is off, turn it on
+        local is_fl_on = G_reader_settings:readSetting("is_frontlight_on")
+        if is_fl_on then
+            -- default is_fl_on is false, turn it on
             powerd:toggleFrontlight()
         else
             -- the light can still be turned on manually outside of koreader
             -- or nickel. so we always set the intensity to 0 here to keep it
-            -- in sync with the default state
+            -- in sync with powerd.is_fl_on (false by default)
             -- NOTE: we cant use setIntensity method here because for kobo the
             -- min intensity is 1 :(
             powerd.fl:setBrightness(0)

--- a/reader.lua
+++ b/reader.lua
@@ -124,8 +124,15 @@ if Device:isKobo() then
         powerd.fl_intensity = intensity or powerd.fl_intensity
         local state = G_reader_settings:readSetting("frontlight_state")
         if state then
-            -- Default state is off
+            -- default state is off, turn it on
             powerd:toggleFrontlight()
+        else
+            -- the light can still be turned on manually outside of koreader
+            -- or nickel. so we always set the intensity to 0 here to keep it
+            -- in sync with the default state
+            -- NOTE: we cant use setIntensity method here because for kobo the
+            -- min intensity is 1 :(
+            powerd.fl:setBrightness(0)
         end
     end
     if Device:getCodeName() == "trilogy" then

--- a/spec/unit/nickel_conf_spec.lua
+++ b/spec/unit/nickel_conf_spec.lua
@@ -59,7 +59,7 @@ bar=baz
 
             NickelConf._set_kobo_conf_path(fn)
             assert.Equals(NickelConf.frontLightLevel.get(), 20)
-            assert.Equals(NickelConf.frontLightState.get(), false)
+            assert.Equals(NickelConf.frontLightState.get(), nil)
 
             os.remove(fn)
         end)
@@ -83,7 +83,6 @@ FrontLightLevel=6
 FrontLightLevel=6
 [PowerOptions]
 FrontLightLevel=100
-FrontLightState=true
 ]])
             fd:close()
             os.remove(fn)
@@ -99,7 +98,6 @@ FrontLightState=true
             assert.Equals(fd:read("*a"), [[
 [PowerOptions]
 FrontLightLevel=20
-FrontLightState=false
 ]])
             fd:close()
             os.remove(fn)
@@ -153,14 +151,13 @@ bar=baz
             NickelConf.frontLightState.set(true)
 
             fd = io.open(fn, "r")
-            assert.Equals(fd:read("*a"), [[
+            assert.Equals([[
 [PowerOptions]
 foo=bar
 FrontLightLevel=1
-FrontLightState=true
 [OtherThing]
 bar=baz
-]])
+]], fd:read("*a"))
             fd:close()
             os.remove(fn)
         end)
@@ -178,7 +175,6 @@ bar=baz
             assert.Equals([[
 [PowerOptions]
 FrontLightLevel=15
-FrontLightState=false
 ]],
                           fd:read("*a"))
             fd:close()


### PR DESCRIPTION
- [x] Keep our own flag for toggling (is_fl_on)
- [x] When reading from nickel, if FrontLightState doesn't exist, check Level != 0 instead
- [x] When reading from nickel, don't write FrontLightState if it didn't exist to begin with
- [x] When writing to nickel, don't write FrontLightState if it didn't exist to begin with
- [x] Always honor the correct state @ reader.lua#L126, even if that means turning the light off
- [x] Always set state to false when user set frontlight intensity to 0 from the ui
- [x] Always set state to true when user set frontlight intensity to larger than 0 from the ui
- [x] make sure it works on kobo aura...